### PR TITLE
feat(ux): add tooltip for address (FE-46)

### DIFF
--- a/src/components/DarkTooltip.js
+++ b/src/components/DarkTooltip.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import Tooltip from '@material-ui/core/Tooltip';
+import { withStyles } from '@material-ui/styles';
+
+const DarkTooltip = withStyles((theme) => ({
+    arrow: {
+        color: theme.palette.common.black,
+    },
+    tooltip: {
+        backgroundColor: theme.palette.common.black,
+    },
+}))(Tooltip);
+
+export default DarkTooltip;

--- a/src/containers/ConfirmContainer.js
+++ b/src/containers/ConfirmContainer.js
@@ -12,6 +12,7 @@ import {
 } from '../utils/txUtils'
 import { MINI_ICON_MAP, SYMBOL_MAP, NAME_MAP, abbreviateAddress } from '../utils/walletUtils'
 
+import DarkTooltip from '../components/DarkTooltip';
 
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
@@ -348,8 +349,12 @@ class ConfirmContainer extends React.Component {
                                           Destination
                                       </Grid>
                                       <Grid item xs={6}>
-                                          <img src={WalletIcon}/>
-                                          {abbreviateAddress(confirmTx.destAddress)}
+                                           <DarkTooltip placement='top' title={confirmTx.destAddress} arrow>
+                                              <div>
+                                                  <img src={WalletIcon}/>
+                                                  {abbreviateAddress(confirmTx.destAddress)}
+                                              </div>
+                                          </DarkTooltip>
                                       </Grid>
                                   </Grid>
 

--- a/src/containers/TransferContainer.js
+++ b/src/containers/TransferContainer.js
@@ -20,7 +20,6 @@ import {
   updateBalance
 } from '../utils/walletUtils'
 
-import Tooltip from '@material-ui/core/Tooltip';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
@@ -29,6 +28,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import CurrencySelect from '../components/CurrencySelect';
 import BigCurrencyInput from '../components/BigCurrencyInput';
+import DarkTooltip from '../components/DarkTooltip';
 import ActionLink from '../components/ActionLink';
 
 import WalletIcon from '../assets/wallet-icon.svg'
@@ -230,14 +230,6 @@ const styles = (theme) => ({
         },
     }
 })
-const DarkTooltip = withStyles((theme) => ({
-    arrow: {
-        color: theme.palette.common.black,
-    },
-    tooltip: {
-        backgroundColor: theme.palette.common.black,
-    },
-}))(Tooltip);
 
 class TransferContainer extends React.Component {
 

--- a/src/containers/TransferContainer.js
+++ b/src/containers/TransferContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withStore } from '@spyna/react-store'
-import { withStyles } from '@material-ui/styles';
+import { withStyles, makeStyles } from '@material-ui/styles';
 import classNames from 'classnames'
 import AddressValidator from "wallet-address-validator";
 import bchaddr from 'bchaddrjs'
@@ -20,6 +20,7 @@ import {
   updateBalance
 } from '../utils/walletUtils'
 
+import Tooltip from '@material-ui/core/Tooltip';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
@@ -229,6 +230,14 @@ const styles = (theme) => ({
         },
     }
 })
+const DarkTooltip = withStyles((theme) => ({
+    arrow: {
+        color: theme.palette.common.black,
+    },
+    tooltip: {
+        backgroundColor: theme.palette.common.black,
+    },
+}))(Tooltip);
 
 class TransferContainer extends React.Component {
 
@@ -480,7 +489,13 @@ class TransferContainer extends React.Component {
                                             Destination
                                         </Grid>
                                         <Grid item xs={6}>
-                                            <img src={WalletIcon}/>{abbreviateAddress(localWeb3Address)}
+
+                                          <DarkTooltip placement='top' title={localWeb3Address} arrow>
+                                            <div>
+                                          <img src={WalletIcon}/>{abbreviateAddress(localWeb3Address)}
+
+                             </div>
+                                          </DarkTooltip>
                                         </Grid>
                                     </Grid>
                                     <Grid container className={classes.option}>


### PR DESCRIPTION
This adds a tooltip to show the full destination address when minting in bridge