### PR TITLE
fix(deletion): allow deleting when localstorage is not present

### DIFF
--- a/src/utils/txUtils.ts
+++ b/src/utils/txUtils.ts
@@ -394,6 +394,7 @@ export const reOpenTx = async function (trade: any, id?: string) {
   const gjs = store.get("gjs");
   const localWeb3 = store.get("localWeb3");
   const gateway = gjs.recoverTransfer(localWeb3.currentProvider, trade, id);
+  trade.id = id;
 
   gateway
     .pause()


### PR DESCRIPTION
The trade won't have an id if gatewayjs cannot persist locally; this fixes that. 